### PR TITLE
for beans discovery created beans.xml

### DIFF
--- a/quarkus-hexagonal-core/src/main/resources/META-INF/beans.xml
+++ b/quarkus-hexagonal-core/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="ISO-8859-5" ?>
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" bean-discovery-mode="all">
+</beans>


### PR DESCRIPTION
For discovery of beans from core module, it needs beans.xml, sharing as otherwise api application was not working